### PR TITLE
Package `mahotas` version `1.4.3`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mahotas" %}
-{% set version = "1.4.1" %}
-{% set sha256 = "40b2ee831b66247541706b28db0d4b187d051d5fda926a0c43912d27b3be50c0" %}
+{% set version = "1.4.3" %}
+{% set sha256 = "e113fb73f1f717f1a9124b41496b030628efb72a23b0150a42ecb18b08b030c4" %}
 
 package:
   name: {{ name|lower }}
@@ -19,7 +19,7 @@ source:
     - PR_81.diff
 
 build:
-  number: 2
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
Closes https://github.com/conda-forge/mahotas-feedstock/issues/3

```
Version 1.4.3 2016-10-03 by luispedro
    * Fix distribution (add missing README.md file)

Version 1.4.2 2016-10-02 by luispedro
    * Fix `resize_to` return exactly the requested size
    * Fix hard crash when computing texture on arrays with negative values
    (issue #72)
    * Added `distance` argument to haralick features (pull request #76, by
Guillaume Lemaitre)
```
