### PR TITLE
Add missing dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -25,6 +25,8 @@ requirements:
   run:
     - python
     - numpy x.x
+    - scipy
+    - pillow
 
 test:
   imports:


### PR DESCRIPTION
Appears the dependencies SciPy and Pillow were missing. This adds them as run time dependencies.
