### PR TITLE
Change doc url

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
     Mahotas is a library of fast computer vision algorithms
     (all implemented in C++) operating over numpy arrays.
 
-  doc_url: http://mahotas.rtfd.io/
+  doc_url: http://mahotas.readthedocs.io/
   dev_url: https://github.com/luispedro/mahotas
 
 extra:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/mahotas-feedstock/issues/10

Use the long readthedocs url for the docs.
